### PR TITLE
[RSpec編] 04_未完成のテストコード修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
-
+vendor/bundle
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+
+    trait :done do
+      status { :done }
+      completion_date { Time.current.yesterday }
+    end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+    association :project
 
     trait :done do
       status { :done }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit project_path(project)
         click_link 'View Todos'
-        visit project_tasks_path(project)
+        switch_to_window(windows.last)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_task_path(project, task)
       end
 
-      fit '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
+      it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
         visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
@@ -88,9 +88,10 @@ RSpec.describe 'Task', type: :system do
     end
   end
   describe 'Task削除' do
+    let!(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      it 'Taskが削除されること' do
+      fit 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit project_path(project)
         click_link 'View Todos'
+        visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
@@ -54,13 +55,13 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        expect(find('.task_list')).to have_content short_time(Time.current)
         expect(current_path).to eq project_tasks_path(project)
       end
 
@@ -91,7 +92,7 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      it 'Taskが削除されること' do
+      fit 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
   let(:project){ create(:project)}
-  let(:task) { create(:task, project_id: project.id)}
+  let(:task) { create(:task)}
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
@@ -24,7 +24,6 @@ RSpec.describe 'Task', type: :system do
       end
     end
   end
-
   describe 'Task新規作成' do
     context '正常系' do
       it 'Taskが新規作成されること' do
@@ -88,7 +87,7 @@ RSpec.describe 'Task', type: :system do
     end
   end
   describe 'Task削除' do
-    let!(:task){ create(:task, project_id: project.id) }
+    let!(:task){ create(:task) }
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
       it 'Taskが削除されること' do

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit project_path(project)
         click_link 'View Todos'
@@ -54,8 +54,9 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task編集' do
+    let(:task_done) { create(:task, :done) }
     context '正常系' do
-      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
@@ -75,10 +76,8 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_task_path(project, task)
       end
 
-      it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
+      fit '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
         visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
@@ -88,11 +87,10 @@ RSpec.describe 'Task', type: :system do
       end
     end
   end
-
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      fit 'Taskが削除されること' do
+      it 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit project_path(project)
         click_link 'View Todos'
@@ -91,11 +91,11 @@ RSpec.describe 'Task', type: :system do
     let!(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      fit 'Taskが削除されること' do
+      it 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(find(".task_list")).not_to have_content task.title
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,22 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
+  let(:project){ create(:project)}
+  let(:task) { create(:task, project_id: project.id)}
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
         click_link 'View Todos'
         expect(page).to have_content task.title
@@ -30,7 +28,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
@@ -46,8 +43,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -59,10 +54,8 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
@@ -73,8 +66,6 @@ RSpec.describe 'Task', type: :system do
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'
@@ -100,9 +91,7 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept


### PR DESCRIPTION
テストコード修正を行いました。
確認よろしくお願いします。


Fixmeの一つ目の’Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること’について質問なのですが
最後に開いたタブに移動できるswitch_to_window(windows.last)
という書き方があると知り、書き換えました。
それまではvisit project_tasks_path(project)としておりテストもパスしていました。
別タブが意図したパスに飛んでいたか確認するためにも書き直すべきと判断しましたが
この認識は合っていますでしょうか？





[![Image from Gyazo](https://i.gyazo.com/010a16325b0cd93f7b863915d457ff33.png)](https://gyazo.com/010a16325b0cd93f7b863915d457ff33)

